### PR TITLE
feat: Add ReadFile and Checksum operations

### DIFF
--- a/pkg/synthfs/file_operations_test.go
+++ b/pkg/synthfs/file_operations_test.go
@@ -1,0 +1,556 @@
+package synthfs_test
+
+import (
+	"context"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/arthur-debert/synthfs/pkg/synthfs"
+	"github.com/arthur-debert/synthfs/pkg/synthfs/filesystem"
+	"github.com/arthur-debert/synthfs/pkg/synthfs/testutil"
+)
+
+func TestReadFile_Basic(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("SynthFS does not officially support Windows")
+	}
+
+	t.Run("read text file", func(t *testing.T) {
+		helper := testutil.NewRealFSTestHelper(t)
+		fs := helper.FileSystem().(filesystem.FullFileSystem)
+		sfs := synthfs.New()
+
+		// Create test file
+		testContent := "Hello, World!\nThis is a test file."
+		testFile := "test.txt"
+		err := fs.WriteFile(testFile, []byte(testContent), 0644)
+		if err != nil {
+			t.Fatalf("Failed to create test file: %v", err)
+		}
+
+		// Read file with operation
+		op := sfs.ReadFile(testFile)
+		result, err := synthfs.Run(context.Background(), fs, op)
+		if err != nil {
+			t.Fatalf("ReadFile operation failed: %v", err)
+		}
+
+		if !result.IsSuccess() {
+			t.Fatalf("ReadFile operation did not succeed: %v", result.GetError())
+		}
+
+		// Verify content was captured
+		content := synthfs.GetOperationOutput(op, "content")
+		if content != testContent {
+			t.Errorf("Expected content %q, got %q", testContent, content)
+		}
+
+		// Verify metadata was captured
+		size := synthfs.GetOperationOutputValue(op, "size")
+		if size == nil {
+			t.Error("Size metadata was not captured")
+		}
+
+		modTime := synthfs.GetOperationOutputValue(op, "modTime")
+		if modTime == nil {
+			t.Error("ModTime metadata was not captured")
+		}
+	})
+
+	t.Run("read empty file", func(t *testing.T) {
+		helper := testutil.NewRealFSTestHelper(t)
+		fs := helper.FileSystem().(filesystem.FullFileSystem)
+		sfs := synthfs.New()
+
+		// Create empty file
+		testFile := "empty.txt"
+		err := fs.WriteFile(testFile, []byte(""), 0644)
+		if err != nil {
+			t.Fatalf("Failed to create empty file: %v", err)
+		}
+
+		// Read empty file
+		op := sfs.ReadFile(testFile)
+		result, err := synthfs.Run(context.Background(), fs, op)
+		if err != nil {
+			t.Fatalf("ReadFile operation failed: %v", err)
+		}
+
+		if !result.IsSuccess() {
+			t.Fatalf("ReadFile operation did not succeed: %v", result.GetError())
+		}
+
+		// Verify empty content
+		content := synthfs.GetOperationOutput(op, "content")
+		if content != "" {
+			t.Errorf("Expected empty content, got %q", content)
+		}
+
+		// Verify size is 0
+		size := synthfs.GetOperationOutputValue(op, "size")
+		if sizeInt, ok := size.(int64); !ok || sizeInt != 0 {
+			t.Errorf("Expected size 0, got %v", size)
+		}
+	})
+
+	t.Run("read with explicit ID", func(t *testing.T) {
+		helper := testutil.NewRealFSTestHelper(t)
+		fs := helper.FileSystem().(filesystem.FullFileSystem)
+		sfs := synthfs.New()
+
+		// Create test file
+		testContent := "Test content for explicit ID"
+		testFile := "explicit_id.txt"
+		err := fs.WriteFile(testFile, []byte(testContent), 0644)
+		if err != nil {
+			t.Fatalf("Failed to create test file: %v", err)
+		}
+
+		// Read file with explicit ID
+		op := sfs.ReadFileWithID("custom_read_id", testFile)
+		result, err := synthfs.Run(context.Background(), fs, op)
+		if err != nil {
+			t.Fatalf("ReadFile operation failed: %v", err)
+		}
+
+		if !result.IsSuccess() {
+			t.Fatalf("ReadFile operation did not succeed: %v", result.GetError())
+		}
+
+		// Verify content was captured
+		content := synthfs.GetOperationOutput(op, "content")
+		if content != testContent {
+			t.Errorf("Expected content %q, got %q", testContent, content)
+		}
+
+		// Verify operation ID
+		if op.ID() != "custom_read_id" {
+			t.Errorf("Expected ID 'custom_read_id', got %q", op.ID())
+		}
+	})
+}
+
+func TestReadFile_ErrorHandling(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("SynthFS does not officially support Windows")
+	}
+
+	t.Run("nonexistent file", func(t *testing.T) {
+		helper := testutil.NewRealFSTestHelper(t)
+		fs := helper.FileSystem().(filesystem.FullFileSystem)
+		sfs := synthfs.New()
+
+		// Try to read nonexistent file
+		op := sfs.ReadFile("nonexistent.txt")
+		result, err := synthfs.Run(context.Background(), fs, op)
+		
+		if err == nil {
+			t.Error("Expected error when reading nonexistent file")
+		}
+
+		if result.IsSuccess() {
+			t.Error("Operation should have failed for nonexistent file")
+		}
+	})
+
+	t.Run("try to read directory", func(t *testing.T) {
+		helper := testutil.NewRealFSTestHelper(t)
+		fs := helper.FileSystem().(filesystem.FullFileSystem)
+		sfs := synthfs.New()
+
+		// Create directory
+		err := fs.MkdirAll("testdir", 0755)
+		if err != nil {
+			t.Fatalf("Failed to create directory: %v", err)
+		}
+
+		// Try to read directory as file
+		op := sfs.ReadFile("testdir")
+		result, err := synthfs.Run(context.Background(), fs, op)
+		
+		if err == nil {
+			t.Error("Expected error when reading directory as file")
+		}
+
+		if result.IsSuccess() {
+			t.Error("Operation should have failed when reading directory")
+		}
+
+		// Check error message
+		if !strings.Contains(err.Error(), "cannot read directory as file") {
+			t.Errorf("Expected specific error message, got: %v", err)
+		}
+	})
+}
+
+func TestChecksum_Basic(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("SynthFS does not officially support Windows")
+	}
+
+	t.Run("md5 checksum", func(t *testing.T) {
+		helper := testutil.NewRealFSTestHelper(t)
+		fs := helper.FileSystem().(filesystem.FullFileSystem)
+		sfs := synthfs.New()
+
+		// Create test file with known content
+		testContent := "Hello, World!"
+		testFile := "test_md5.txt"
+		err := fs.WriteFile(testFile, []byte(testContent), 0644)
+		if err != nil {
+			t.Fatalf("Failed to create test file: %v", err)
+		}
+
+		// Calculate MD5 checksum
+		op := sfs.Checksum(testFile, synthfs.MD5)
+		result, err := synthfs.Run(context.Background(), fs, op)
+		if err != nil {
+			t.Fatalf("Checksum operation failed: %v", err)
+		}
+
+		if !result.IsSuccess() {
+			t.Fatalf("Checksum operation did not succeed: %v", result.GetError())
+		}
+
+		// Verify MD5 checksum (expected: 65a8e27d8879283831b664bd8b7f0ad4)
+		md5Hash := synthfs.GetOperationOutput(op, "md5")
+		expectedMD5 := "65a8e27d8879283831b664bd8b7f0ad4"
+		if md5Hash != expectedMD5 {
+			t.Errorf("Expected MD5 %s, got %s", expectedMD5, md5Hash)
+		}
+
+		// Verify algorithm was stored
+		algorithm := synthfs.GetOperationOutput(op, "algorithm")
+		if algorithm != "md5" {
+			t.Errorf("Expected algorithm 'md5', got %s", algorithm)
+		}
+
+		// Verify metadata was captured
+		size := synthfs.GetOperationOutputValue(op, "size")
+		if size == nil {
+			t.Error("Size metadata was not captured")
+		}
+
+		modTime := synthfs.GetOperationOutputValue(op, "modTime")
+		if modTime == nil {
+			t.Error("ModTime metadata was not captured")
+		}
+	})
+
+	t.Run("sha1 checksum", func(t *testing.T) {
+		helper := testutil.NewRealFSTestHelper(t)
+		fs := helper.FileSystem().(filesystem.FullFileSystem)
+		sfs := synthfs.New()
+
+		// Create test file
+		testContent := "Hello, World!"
+		testFile := "test_sha1.txt"
+		err := fs.WriteFile(testFile, []byte(testContent), 0644)
+		if err != nil {
+			t.Fatalf("Failed to create test file: %v", err)
+		}
+
+		// Calculate SHA1 checksum
+		op := sfs.Checksum(testFile, synthfs.SHA1)
+		result, err := synthfs.Run(context.Background(), fs, op)
+		if err != nil {
+			t.Fatalf("Checksum operation failed: %v", err)
+		}
+
+		if !result.IsSuccess() {
+			t.Fatalf("Checksum operation did not succeed: %v", result.GetError())
+		}
+
+		// Verify SHA1 checksum (expected: 0a0a9f2a6772942557ab5355d76af442f8f65e01)
+		sha1Hash := synthfs.GetOperationOutput(op, "sha1")
+		expectedSHA1 := "0a0a9f2a6772942557ab5355d76af442f8f65e01"
+		if sha1Hash != expectedSHA1 {
+			t.Errorf("Expected SHA1 %s, got %s", expectedSHA1, sha1Hash)
+		}
+
+		// Verify algorithm was stored
+		algorithm := synthfs.GetOperationOutput(op, "algorithm")
+		if algorithm != "sha1" {
+			t.Errorf("Expected algorithm 'sha1', got %s", algorithm)
+		}
+	})
+
+	t.Run("sha256 checksum", func(t *testing.T) {
+		helper := testutil.NewRealFSTestHelper(t)
+		fs := helper.FileSystem().(filesystem.FullFileSystem)
+		sfs := synthfs.New()
+
+		// Create test file
+		testContent := "Hello, World!"
+		testFile := "test_sha256.txt"
+		err := fs.WriteFile(testFile, []byte(testContent), 0644)
+		if err != nil {
+			t.Fatalf("Failed to create test file: %v", err)
+		}
+
+		// Calculate SHA256 checksum
+		op := sfs.Checksum(testFile, synthfs.SHA256)
+		result, err := synthfs.Run(context.Background(), fs, op)
+		if err != nil {
+			t.Fatalf("Checksum operation failed: %v", err)
+		}
+
+		if !result.IsSuccess() {
+			t.Fatalf("Checksum operation did not succeed: %v", result.GetError())
+		}
+
+		// Verify SHA256 checksum (expected: dffd6021bb2bd5b0af676290809ec3a53191dd81c7f70a4b28688a362182986f)
+		sha256Hash := synthfs.GetOperationOutput(op, "sha256")
+		expectedSHA256 := "dffd6021bb2bd5b0af676290809ec3a53191dd81c7f70a4b28688a362182986f"
+		if sha256Hash != expectedSHA256 {
+			t.Errorf("Expected SHA256 %s, got %s", expectedSHA256, sha256Hash)
+		}
+	})
+
+	t.Run("sha512 checksum", func(t *testing.T) {
+		helper := testutil.NewRealFSTestHelper(t)
+		fs := helper.FileSystem().(filesystem.FullFileSystem)
+		sfs := synthfs.New()
+
+		// Create test file
+		testContent := "Hello, World!"
+		testFile := "test_sha512.txt"
+		err := fs.WriteFile(testFile, []byte(testContent), 0644)
+		if err != nil {
+			t.Fatalf("Failed to create test file: %v", err)
+		}
+
+		// Calculate SHA512 checksum
+		op := sfs.Checksum(testFile, synthfs.SHA512)
+		result, err := synthfs.Run(context.Background(), fs, op)
+		if err != nil {
+			t.Fatalf("Checksum operation failed: %v", err)
+		}
+
+		if !result.IsSuccess() {
+			t.Fatalf("Checksum operation did not succeed: %v", result.GetError())
+		}
+
+		// Verify SHA512 checksum exists and is correct length
+		sha512Hash := synthfs.GetOperationOutput(op, "sha512")
+		expectedSHA512 := "374d794a95cdcfd8b35993185fef9ba368f160d8daf432d08ba9f1ed1e5abe6cc69291e0fa2fe0006a52570ef18c19def4e617c33ce52ef0a6e5fbe318cb0387"
+		if sha512Hash != expectedSHA512 {
+			t.Errorf("Expected SHA512 %s, got %s", expectedSHA512, sha512Hash)
+		}
+
+		// Verify it's 128 hex characters (512 bits / 4 bits per hex char)
+		if len(sha512Hash) != 128 {
+			t.Errorf("Expected SHA512 hash length 128, got %d", len(sha512Hash))
+		}
+	})
+
+	t.Run("checksum with explicit ID", func(t *testing.T) {
+		helper := testutil.NewRealFSTestHelper(t)
+		fs := helper.FileSystem().(filesystem.FullFileSystem)
+		sfs := synthfs.New()
+
+		// Create test file
+		testContent := "Test content for explicit ID"
+		testFile := "explicit_checksum.txt"
+		err := fs.WriteFile(testFile, []byte(testContent), 0644)
+		if err != nil {
+			t.Fatalf("Failed to create test file: %v", err)
+		}
+
+		// Calculate checksum with explicit ID
+		op := sfs.ChecksumWithID("custom_checksum_id", testFile, synthfs.MD5)
+		result, err := synthfs.Run(context.Background(), fs, op)
+		if err != nil {
+			t.Fatalf("Checksum operation failed: %v", err)
+		}
+
+		if !result.IsSuccess() {
+			t.Fatalf("Checksum operation did not succeed: %v", result.GetError())
+		}
+
+		// Verify checksum was captured
+		md5Hash := synthfs.GetOperationOutput(op, "md5")
+		if md5Hash == "" {
+			t.Error("MD5 checksum was not captured")
+		}
+
+		// Verify operation ID
+		if op.ID() != "custom_checksum_id" {
+			t.Errorf("Expected ID 'custom_checksum_id', got %q", op.ID())
+		}
+	})
+}
+
+func TestChecksum_ErrorHandling(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("SynthFS does not officially support Windows")
+	}
+
+	t.Run("nonexistent file", func(t *testing.T) {
+		helper := testutil.NewRealFSTestHelper(t)
+		fs := helper.FileSystem().(filesystem.FullFileSystem)
+		sfs := synthfs.New()
+
+		// Try to checksum nonexistent file
+		op := sfs.Checksum("nonexistent.txt", synthfs.MD5)
+		result, err := synthfs.Run(context.Background(), fs, op)
+		
+		if err == nil {
+			t.Error("Expected error when checksumming nonexistent file")
+		}
+
+		if result.IsSuccess() {
+			t.Error("Operation should have failed for nonexistent file")
+		}
+	})
+
+	t.Run("try to checksum directory", func(t *testing.T) {
+		helper := testutil.NewRealFSTestHelper(t)
+		fs := helper.FileSystem().(filesystem.FullFileSystem)
+		sfs := synthfs.New()
+
+		// Create directory
+		err := fs.MkdirAll("testdir", 0755)
+		if err != nil {
+			t.Fatalf("Failed to create directory: %v", err)
+		}
+
+		// Try to checksum directory
+		op := sfs.Checksum("testdir", synthfs.MD5)
+		result, err := synthfs.Run(context.Background(), fs, op)
+		
+		if err == nil {
+			t.Error("Expected error when checksumming directory")
+		}
+
+		if result.IsSuccess() {
+			t.Error("Operation should have failed when checksumming directory")
+		}
+
+		// Check error message
+		if !strings.Contains(err.Error(), "cannot checksum directory") {
+			t.Errorf("Expected specific error message, got: %v", err)
+		}
+	})
+}
+
+func TestFileOperations_InPipeline(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("SynthFS does not officially support Windows")
+	}
+
+	t.Run("read and checksum in pipeline", func(t *testing.T) {
+		helper := testutil.NewRealFSTestHelper(t)
+		fs := helper.FileSystem().(filesystem.FullFileSystem)
+		sfs := synthfs.New()
+
+		// Create test content
+		testContent := "This is test content for pipeline processing!"
+		testFile := "pipeline_test.txt"
+
+		// Run pipeline that creates file, reads it, and checksums it
+		readOp := sfs.ReadFile(testFile)
+		checksumOp := sfs.Checksum(testFile, synthfs.SHA256)
+		
+		result, err := synthfs.Run(context.Background(), fs,
+			sfs.CreateFile(testFile, []byte(testContent), 0644),
+			readOp,
+			checksumOp,
+		)
+
+		if err != nil {
+			t.Fatalf("Pipeline failed: %v", err)
+		}
+
+		if !result.IsSuccess() {
+			t.Fatalf("Pipeline did not succeed: %v", result.GetError())
+		}
+
+		// Verify read operation captured content
+		content := synthfs.GetOperationOutput(readOp, "content")
+		if content != testContent {
+			t.Errorf("Expected content %q, got %q", testContent, content)
+		}
+
+		// Verify checksum operation calculated hash
+		hash := synthfs.GetOperationOutput(checksumOp, "sha256")
+		if hash == "" {
+			t.Error("SHA256 checksum was not calculated")
+		}
+
+		// Verify both operations captured size metadata
+		readSize := synthfs.GetOperationOutputValue(readOp, "size")
+		checksumSize := synthfs.GetOperationOutputValue(checksumOp, "size")
+		
+		if readSize != checksumSize {
+			t.Errorf("Size mismatch between read (%v) and checksum (%v)", readSize, checksumSize)
+		}
+
+		expectedSize := int64(len(testContent))
+		if readSize != expectedSize {
+			t.Errorf("Expected size %d, got %v", expectedSize, readSize)
+		}
+	})
+
+	t.Run("multiple checksums of same file", func(t *testing.T) {
+		helper := testutil.NewRealFSTestHelper(t)
+		fs := helper.FileSystem().(filesystem.FullFileSystem)
+		sfs := synthfs.New()
+
+		// Create test file
+		testContent := "Content for multiple checksums"
+		testFile := "multi_checksum.txt"
+
+		// Calculate multiple checksums with explicit IDs to avoid collision
+		md5Op := sfs.ChecksumWithID("md5_checksum", testFile, synthfs.MD5)
+		sha1Op := sfs.ChecksumWithID("sha1_checksum", testFile, synthfs.SHA1)
+		sha256Op := sfs.ChecksumWithID("sha256_checksum", testFile, synthfs.SHA256)
+
+		result, err := synthfs.Run(context.Background(), fs,
+			sfs.CreateFile(testFile, []byte(testContent), 0644),
+			md5Op,
+			sha1Op,
+			sha256Op,
+		)
+
+		if err != nil {
+			t.Fatalf("Pipeline failed: %v", err)
+		}
+
+		if !result.IsSuccess() {
+			t.Fatalf("Pipeline did not succeed: %v", result.GetError())
+		}
+
+		// Verify all checksums were calculated
+		md5Hash := synthfs.GetOperationOutput(md5Op, "md5")
+		sha1Hash := synthfs.GetOperationOutput(sha1Op, "sha1")
+		sha256Hash := synthfs.GetOperationOutput(sha256Op, "sha256")
+
+		if md5Hash == "" {
+			t.Error("MD5 checksum was not calculated")
+		}
+		if sha1Hash == "" {
+			t.Error("SHA1 checksum was not calculated")
+		}
+		if sha256Hash == "" {
+			t.Error("SHA256 checksum was not calculated")
+		}
+
+		// Verify all different
+		if md5Hash == sha1Hash || md5Hash == sha256Hash || sha1Hash == sha256Hash {
+			t.Error("Different hash algorithms should produce different results")
+		}
+
+		// Verify expected lengths
+		if len(md5Hash) != 32 {
+			t.Errorf("MD5 hash should be 32 chars, got %d", len(md5Hash))
+		}
+		if len(sha1Hash) != 40 {
+			t.Errorf("SHA1 hash should be 40 chars, got %d", len(sha1Hash))
+		}
+		if len(sha256Hash) != 64 {
+			t.Errorf("SHA256 hash should be 64 chars, got %d", len(sha256Hash))
+		}
+	})
+}

--- a/pkg/synthfs/synthfs.go
+++ b/pkg/synthfs/synthfs.go
@@ -1,9 +1,18 @@
 package synthfs
 
 import (
+	"context"
+	"crypto/md5"
+	"crypto/sha1"
+	"crypto/sha256"
+	"crypto/sha512"
+	"fmt"
+	"hash"
+	"io"
 	"io/fs"
 
 	"github.com/arthur-debert/synthfs/pkg/synthfs/core"
+	"github.com/arthur-debert/synthfs/pkg/synthfs/filesystem"
 	"github.com/arthur-debert/synthfs/pkg/synthfs/operations"
 	"github.com/arthur-debert/synthfs/pkg/synthfs/targets"
 )
@@ -163,5 +172,154 @@ func (s *SynthFS) CustomOperationWithOutput(name string, executeFunc CustomOpera
 // CustomOperationWithOutputAndID creates a custom operation with explicit ID that can store output.
 func (s *SynthFS) CustomOperationWithOutputAndID(id string, executeFunc CustomOperationWithOutputFunc) Operation {
 	op := NewCustomOperationWithOutput(id, executeFunc)
+	return NewCustomOperationAdapter(op)
+}
+
+// ReadFile creates a file read operation with auto-generated ID.
+// The file content is captured and stored as "content" output.
+//
+// Example:
+//   op := sfs.ReadFile("/path/to/file")
+//   result, _ := synthfs.Run(ctx, fs, op)
+//   content := GetOperationOutput(op, "content")
+func (s *SynthFS) ReadFile(path string) Operation {
+	id := s.idGen("read_file", path)
+	return s.ReadFileWithID(string(id), path)
+}
+
+// ReadFileWithID creates a file read operation with explicit ID.
+func (s *SynthFS) ReadFileWithID(id string, path string) Operation {
+	op := NewCustomOperationWithOutput(id, func(ctx context.Context, fs filesystem.FileSystem, storeOutput func(string, interface{})) error {
+		// Cast to FullFileSystem to access Stat
+		fullFS, ok := fs.(filesystem.FullFileSystem)
+		if !ok {
+			return fmt.Errorf("filesystem does not support Stat operation")
+		}
+		
+		// Check if file exists and is readable
+		info, err := fullFS.Stat(path)
+		if err != nil {
+			return fmt.Errorf("failed to stat file %s: %w", path, err)
+		}
+		
+		if info.IsDir() {
+			return fmt.Errorf("cannot read directory as file: %s", path)
+		}
+		
+		// Open and read file content
+		file, err := fs.Open(path)
+		if err != nil {
+			return fmt.Errorf("failed to open file %s: %w", path, err)
+		}
+		defer func() {
+			if closeErr := file.Close(); closeErr != nil {
+				// Log the close error, but don't override the main operation error
+				_ = closeErr
+			}
+		}()
+		
+		content, err := io.ReadAll(file)
+		if err != nil {
+			return fmt.Errorf("failed to read file %s: %w", path, err)
+		}
+		
+		// Store file content and metadata
+		storeOutput("content", string(content))
+		storeOutput("size", info.Size())
+		storeOutput("modTime", info.ModTime())
+		
+		return nil
+	})
+	
+	op = op.WithDescription(fmt.Sprintf("Read file: %s", path))
+	return NewCustomOperationAdapter(op)
+}
+
+// ChecksumAlgorithm represents supported checksum algorithms
+type ChecksumAlgorithm string
+
+const (
+	MD5    ChecksumAlgorithm = "md5"
+	SHA1   ChecksumAlgorithm = "sha1" 
+	SHA256 ChecksumAlgorithm = "sha256"
+	SHA512 ChecksumAlgorithm = "sha512"
+)
+
+// Checksum creates a checksum operation with auto-generated ID.
+// The checksum value is stored as output using the algorithm name (e.g., "md5", "sha256").
+// Additional metadata like size and modTime are also stored.
+//
+// Example:
+//   op := sfs.Checksum("/path/to/file", SHA256)
+//   result, _ := synthfs.Run(ctx, fs, op)
+//   hash := GetOperationOutput(op, "sha256")
+func (s *SynthFS) Checksum(path string, algorithm ChecksumAlgorithm) Operation {
+	id := s.idGen("checksum", path)
+	return s.ChecksumWithID(string(id), path, algorithm)
+}
+
+// ChecksumWithID creates a checksum operation with explicit ID.
+func (s *SynthFS) ChecksumWithID(id string, path string, algorithm ChecksumAlgorithm) Operation {
+	op := NewCustomOperationWithOutput(id, func(ctx context.Context, fs filesystem.FileSystem, storeOutput func(string, interface{})) error {
+		// Cast to FullFileSystem to access Stat
+		fullFS, ok := fs.(filesystem.FullFileSystem)
+		if !ok {
+			return fmt.Errorf("filesystem does not support Stat operation")
+		}
+		
+		// Check if file exists and is readable
+		info, err := fullFS.Stat(path)
+		if err != nil {
+			return fmt.Errorf("failed to stat file %s: %w", path, err)
+		}
+		
+		if info.IsDir() {
+			return fmt.Errorf("cannot checksum directory: %s", path)
+		}
+		
+		// Open file for reading
+		file, err := fs.Open(path)
+		if err != nil {
+			return fmt.Errorf("failed to open file %s: %w", path, err)
+		}
+		defer func() {
+			if closeErr := file.Close(); closeErr != nil {
+				// Log the close error, but don't override the main operation error
+				_ = closeErr
+			}
+		}()
+		
+		// Create appropriate hash algorithm
+		var hasher hash.Hash
+		switch algorithm {
+		case MD5:
+			hasher = md5.New()
+		case SHA1:
+			hasher = sha1.New()
+		case SHA256:
+			hasher = sha256.New()
+		case SHA512:
+			hasher = sha512.New()
+		default:
+			return fmt.Errorf("unsupported checksum algorithm: %s", algorithm)
+		}
+		
+		// Calculate checksum
+		if _, err := io.Copy(hasher, file); err != nil {
+			return fmt.Errorf("failed to calculate %s checksum for %s: %w", algorithm, path, err)
+		}
+		
+		checksumValue := fmt.Sprintf("%x", hasher.Sum(nil))
+		
+		// Store checksum and metadata
+		storeOutput(string(algorithm), checksumValue)
+		storeOutput("size", info.Size())
+		storeOutput("modTime", info.ModTime())
+		storeOutput("algorithm", string(algorithm))
+		
+		return nil
+	})
+	
+	op = op.WithDescription(fmt.Sprintf("Calculate %s checksum: %s", algorithm, path))
 	return NewCustomOperationAdapter(op)
 }


### PR DESCRIPTION
## Summary
- Implement ReadFile operation that captures file content as output for pipeline processing (closes #59)
- Implement Checksum operation with support for MD5, SHA1, SHA256, SHA512 algorithms (closes #60)
- Both operations follow existing patterns using NewCustomOperationWithOutput
- Comprehensive test coverage with real filesystem testing
- Pipeline integration with proper output capture and metadata

## Test plan
- [x] Unit tests for ReadFile operation with various scenarios
- [x] Unit tests for Checksum operation with all supported algorithms  
- [x] Error handling tests for both operations
- [x] Pipeline integration tests
- [x] Linting checks pass
- [x] All existing tests continue to pass

🤖 Generated with [Claude Code](https://claude.ai/code)