### PR TITLE
fix: make directory creation idempotent in batch operations

### DIFF
--- a/pkg/synthfs/core/prerequisites_test.go
+++ b/pkg/synthfs/core/prerequisites_test.go
@@ -2,7 +2,9 @@ package core
 
 import (
 	"fmt"
+	"io/fs"
 	"testing"
+	"time"
 )
 
 // MockFileSystem implements the basic interfaces needed for prerequisite testing
@@ -10,15 +12,20 @@ type MockFileSystem struct {
 	files map[string]MockFileInfo
 }
 
-// MockFileInfo implements the FileInfo interface
+// MockFileInfo implements the fs.FileInfo interface
 type MockFileInfo struct {
 	name  string
 	isDir bool
+	size  int64
+	mode  fs.FileMode
 }
 
-func (f MockFileInfo) IsDir() bool {
-	return f.isDir
-}
+func (f MockFileInfo) Name() string       { return f.name }
+func (f MockFileInfo) Size() int64        { return f.size }
+func (f MockFileInfo) Mode() fs.FileMode  { return f.mode }
+func (f MockFileInfo) ModTime() time.Time { return time.Now() }
+func (f MockFileInfo) IsDir() bool        { return f.isDir }
+func (f MockFileInfo) Sys() interface{}   { return nil }
 
 func NewMockFileSystem() *MockFileSystem {
 	return &MockFileSystem{
@@ -26,7 +33,7 @@ func NewMockFileSystem() *MockFileSystem {
 	}
 }
 
-func (fs *MockFileSystem) Stat(name string) (interface{}, error) {
+func (fs *MockFileSystem) Stat(name string) (fs.FileInfo, error) {
 	if info, exists := fs.files[name]; exists {
 		return info, nil
 	}

--- a/pkg/synthfs/execution/state.go
+++ b/pkg/synthfs/execution/state.go
@@ -233,6 +233,13 @@ func (pst *PathStateTracker) updateStateForCreate(opID core.OperationID, path st
 	}
 
 	if state.WillExist {
+		// Special handling for directory creation - it's idempotent
+		if createType == core.PathStateDir && state.WillBeType == core.PathStateDir {
+			// Directory creation is idempotent - creating a directory that already exists should succeed
+			// This matches the behavior of 'mkdir -p' and individual directory operation validation
+			return nil
+		}
+		
 		return fmt.Errorf("operation %s conflicts with existing state: cannot create %s because it is projected to already exist", opID, path)
 	}
 	if state.DeletedBy != "" {

--- a/pkg/synthfs/operations/directory.go
+++ b/pkg/synthfs/operations/directory.go
@@ -28,8 +28,9 @@ func (op *CreateDirectoryOperation) Prerequisites() []core.Prerequisite {
 	// Always need parent directory to exist (even if it's current directory)
 	prereqs = append(prereqs, core.NewParentDirPrerequisite(op.description.Path))
 
-	// Need no conflict with existing files (even though mkdir is idempotent for directories)
-	prereqs = append(prereqs, core.NewNoConflictPrerequisite(op.description.Path))
+	// Note: We don't use NoConflictPrerequisite because directory creation is idempotent.
+	// If a directory already exists, the operation should succeed (like mkdir -p).
+	// The individual Validate() method handles conflict detection properly.
 
 	return prereqs
 }

--- a/pkg/synthfs/operations/prerequisites_test.go
+++ b/pkg/synthfs/operations/prerequisites_test.go
@@ -56,13 +56,12 @@ func TestOperationPrerequisites(t *testing.T) {
 		op := NewCreateDirectoryOperation(core.OperationID("test-op"), "parent/newdir")
 
 		prereqs := op.Prerequisites()
-		if len(prereqs) != 2 {
-			t.Errorf("Expected 2 prerequisites, got %d", len(prereqs))
+		if len(prereqs) != 1 {
+			t.Errorf("Expected 1 prerequisite, got %d", len(prereqs))
 		}
 
 		// Check for parent directory prerequisite
 		hasParentDir := false
-		hasNoConflict := false
 
 		for _, prereq := range prereqs {
 			switch prereq.Type() {
@@ -71,20 +70,17 @@ func TestOperationPrerequisites(t *testing.T) {
 				if prereq.Path() != "parent" {
 					t.Errorf("Expected parent_dir path 'parent', got '%s'", prereq.Path())
 				}
-			case "no_conflict":
-				hasNoConflict = true
-				if prereq.Path() != "parent/newdir" {
-					t.Errorf("Expected no_conflict path 'parent/newdir', got '%s'", prereq.Path())
-				}
+			default:
+				t.Errorf("Unexpected prerequisite type: %s", prereq.Type())
 			}
 		}
 
 		if !hasParentDir {
 			t.Error("Expected parent_dir prerequisite")
 		}
-		if !hasNoConflict {
-			t.Error("Expected no_conflict prerequisite")
-		}
+		
+		// Note: NoConflictPrerequisite was intentionally removed from directory operations
+		// because directory creation is idempotent (like 'mkdir -p')
 	})
 
 	t.Run("CreateSymlinkOperation Prerequisites", func(t *testing.T) {


### PR DESCRIPTION
## Summary

Fixes directory creation in batch operations to behave like `mkdir -p`, succeeding when the target directory already exists instead of failing with "conflicts with existing state".

## Problem

Users reported that batch operations would fail when trying to create directories that already exist, even though:
- Individual directory operations work correctly (idempotent)
- This conflicts with standard `mkdir -p` behavior
- The behavior was inconsistent between different execution paths

## Root Cause

The issue had **two layers**:

1. **Prerequisites interface mismatch**: Prerequisites expected `Stat(string) (interface{}, error)` but filesystems implement `Stat(string) (fs.FileInfo, error)`, causing validation failures.

2. **Batch state validation too strict**: The `PathStateTracker` prevented any operation from creating something that already exists, conflicting with idempotent directory behavior.

## Solution

### 1. Fix Prerequisites Interface
- Updated all prerequisites to use correct `fs.FileInfo` interface
- Fixed `ParentDirPrerequisite`, `NoConflictPrerequisite`, and `SourceExistsPrerequisite`
- Updated test mocks to implement proper `fs.FileInfo` interface

### 2. Make Batch Validation Idempotent for Directories
- Modified `updateStateForCreate()` in `PathStateTracker` to allow directory creation when both existing and new items are directories
- Preserves strict validation for file conflicts (directory over file still fails)

### 3. Remove Unnecessary Prerequisite
- Removed `NoConflictPrerequisite` from directory operations since they should be idempotent
- Updated tests to reflect this architectural change

## Test Plan

- [x] Batch operations creating existing directories now succeed
- [x] Multiple operations creating same directory work correctly  
- [x] File/directory conflicts still properly fail
- [x] All existing tests continue to pass
- [x] Prerequisites validation now works correctly
- [x] No regressions in individual operation behavior

## Examples

**Before (❌ Failed):**
```go
// Pre-create directory
fs.MkdirAll("existing_dir", 0755)

// This would fail with "conflicts with existing state"
result, err := synthfs.Run(ctx, fs, sfs.CreateDir("existing_dir", 0755))
```

**After (✅ Success):**
```go
// Pre-create directory  
fs.MkdirAll("existing_dir", 0755)

// This now succeeds (idempotent like mkdir -p)
result, err := synthfs.Run(ctx, fs, sfs.CreateDir("existing_dir", 0755))
```

## Files Changed

- `pkg/synthfs/core/prerequisites.go` - Fix interface signatures
- `pkg/synthfs/execution/state.go` - Add directory idempotency logic  
- `pkg/synthfs/operations/directory.go` - Remove unnecessary prerequisite
- `pkg/synthfs/core/prerequisites_test.go` - Update test mocks
- `pkg/synthfs/operations/prerequisites_test.go` - Update test expectations

## Related Issues

This fix resolves the immediate directory creation issue and exposes deeper architectural questions about validation system redundancy that are tracked in #63.

---

🤖 Generated with [Claude Code](https://claude.ai/code)