### PR TITLE
refactor: remove legacy validator support from batch package

### DIFF
--- a/pkg/synthfs/batch/batch.go
+++ b/pkg/synthfs/batch/batch.go
@@ -97,7 +97,7 @@ func (b *BatchImpl) add(op interface{}) error {
 
 // validateOperation validates an operation
 func (b *BatchImpl) validateOperation(op interface{}) error {
-	// Try ExecutionContext-aware Validate method first with concrete types
+	// Check if operation implements the Validate method
 	type validator interface {
 		Validate(ctx context.Context, execCtx *core.ExecutionContext, fsys filesystem.FileSystem) error
 	}
@@ -106,18 +106,6 @@ func (b *BatchImpl) validateOperation(op interface{}) error {
 		// Create a minimal ExecutionContext for validation
 		execCtx := &core.ExecutionContext{}
 		if err := v.Validate(b.ctx, execCtx, b.fs); err != nil {
-			return err
-		}
-		return nil
-	}
-
-	// Fallback to legacy Validate method (for compatibility)
-	type legacyValidator interface {
-		Validate(ctx context.Context, fsys interface{}) error
-	}
-
-	if v, ok := op.(legacyValidator); ok {
-		if err := v.Validate(b.ctx, b.fs); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
## Overview

This PR removes the legacy validator fallback code from the batch package, completing the transition to the new validation interface.

## Changes

- Removed the legacy validator interface and fallback code that supported the old  signature
- All operations now exclusively use the new  signature
- Simplified the  method in BatchImpl

## Code Removed

The following legacy code was removed:
- Legacy validator interface type definition
- Fallback logic that checked for and called the old Validate method
- Associated comments about compatibility

## Benefits

- Cleaner, more maintainable code
- Single validation path instead of two
- Removes technical debt from the transition period
- Consistent with the consolidated interface design

## Testing

- All 830 tests pass
- No linting issues
- Pre-commit hooks pass

## Notes

While checking for legacy code, I noticed that the pipeline interfaces (, ) still use the old Validate signature. This appears to be a separate concern that should be addressed in a different PR as part of the broader pipeline refactoring.

This is part of the interface consolidation effort (issue #65).