### PR TITLE
Unify BuildPipeline to use Simple API execution path (Issue #81)

### DIFF
--- a/pkg/synthfs/pipeline_builder_test.go
+++ b/pkg/synthfs/pipeline_builder_test.go
@@ -129,16 +129,16 @@ func TestPipelineBuilder(t *testing.T) {
 		}
 	})
 
-	t.Run("Pipeline with custom executor", func(t *testing.T) {
+	t.Run("Pipeline execution with WithOptions", func(t *testing.T) {
 		ResetSequenceCounter()
 		ctx := context.Background()
 		fs := filesystem.NewTestFileSystem()
 
-		customExecutor := NewExecutor()
+		options := DefaultPipelineOptions()
 
 		_, err := BuildPipeline(
 			sfs.CreateDir("custom", 0755),
-		).ExecuteWith(ctx, fs, customExecutor)
+		).WithOptions(options).Execute(ctx, fs)
 
 		if err != nil {
 			t.Fatalf("Pipeline execution failed: %v", err)


### PR DESCRIPTION
## Summary
- Remove `ExecuteWith()` method from PipelineBuilder to eliminate adapter dependency
- Update `PipelineExecutor.Execute()` to use `RunWithOptions()` directly
- Update tests to use `WithOptions().Execute()` instead of the removed method

## Changes Made
- **Removed**: `PipelineBuilder.ExecuteWith()` method that used the adapter-based executor
- **Updated**: `PipelineExecutor.Execute()` now delegates to `RunWithOptions()` for direct execution
- **Fixed**: Test that was using the removed `ExecuteWith()` method

## Impact
This eliminates BuildPipeline's dependency on the adapter system, following the same successful pattern used for Simple API unification. BuildPipeline now uses the same direct execution path as Simple API.

## Test Results
✅ All 752 tests pass
✅ Linting passes with 0 issues
✅ Pre-commit hooks pass

## Next Steps
With BuildPipeline unified, Issue #79 (remove adapters) can proceed safely since no execution paths will depend on the adapter system.

Closes #81

🤖 Generated with [Claude Code](https://claude.ai/code)